### PR TITLE
問題 62 の解答が PDF 版と異なっていたため修正しました。

### DIFF
--- a/answer/62.md
+++ b/answer/62.md
@@ -1,6 +1,6 @@
 ### 解答
 ```
- $ nkf -wLux syukujitsu.csv | tail -n +2 | teip -d, -f 1 -- date -f- '+%Y-%m-%d' | awk -F- '$1>=2019' | cat - <(dateutils.dseq 2019-01-01 2021-12-31 | sed 's/$/,@/')  | sort -r | uniq -w10 | tac
+ $ nkf -wLux syukujitsu.csv | tail -n +2 | teip -d, -f 1 -- date -f- '+%Y-%m-%d' | awk -F- '$1>=2019&&$1<2022' | cat - <(dateutils.dseq 2019-01-01 2021-12-31 | sed 's/$/,@/') | sort -r | uniq -w10 | tac
 ```
 ### 別解
 ```


### PR DESCRIPTION
PDF 版では awk の抽出条件に「2022 年より前」が入っていましたが、
ファイルでは入っていませんでした。
（qdata/62/syukujitsu.csv ではどちらでも結果は変わらないのですが…）