### PR TITLE
PDF 版と解答が異なっていたため修正しました

### DIFF
--- a/answer/85.md
+++ b/answer/85.md
@@ -5,5 +5,5 @@ $ echo 🍑 🍓 | xargs -n1 | perl -nlE 'say unpack("H*",$_)' | xargs | awk '{p
 ### 別解
 ```
 別解1（上田）$ echo 🍑 🍓 | xxd -i | mawk -F, '{for(i=1;i<=4;i++){printf("%x", ($i + $(i+5))/2)}}' | xxd -p -r
-別解2（田代）$ echo 🍑🍓 | xxd -u -p -l 4 | sed 's/^/obase=16;ibase=16;/;s/$/+1/' | bc | xxd -p -r
+別解2（田代）$ echo 🍑 🍓 | xxd -u -p -l 4 | sed 's/^/obase=16;ibase=16;/;s/$/+1/' | bc | xxd -p -r
 ```


### PR DESCRIPTION
echo の🍑と🍓の間に半角スペースがありませんでした。
（結果は変わりませんが、問題文に（絵文字の間に半角スペースあり）との記載があったので…）