### PR TITLE
練習1.3.aの小問2に別解を追加

### DIFF
--- a/answer/practice-1.3.a.md
+++ b/answer/practice-1.3.a.md
@@ -1,0 +1,7 @@
+### 読者別解
+
+by [mikkun](https://github.com/mikkun)
+
+```
+小問2別解 $ echo クロロエチルエチルエーテル | sed 's/エ/メ/2'
+```


### PR DESCRIPTION
## 小問2別解のコマンドおよび実行結果

```shell
$ echo クロロエチルエチルエーテル | sed 's/エ/メ/2'
クロロエチルメチルエーテル
```

## 小問2別解について

`sed`の「`s/正規表現/置換後の文字列/数字`」で指定番目のマッチ文字列だけを置換することができますので、`sed 's/エ/メ/2'`で2番目にマッチした「エ」を「メ」に変えています。